### PR TITLE
Create a .gitignore on config creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,16 @@ Run:
 wo config set cli $PWD/project/cli2
 ```
 
+### Committing the workspace
+
+You can commit and push the workspace folders on a repository, they are located at:
+
+``` sh
+wo global get config-dir
+```
+
+A default `.gitignore` is provided to exclude all environment variables, at the moment the process of committing and pushing the workspaces is manual. 
+
 ### To go further
 
 Check the help of the command line

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -327,6 +327,10 @@ func (s WorkspaceManager) listEnvs(name string) ([]Env, error) {
 	return envs, err
 }
 
+func (s WorkspaceManager) resolveGitignoreFile() string {
+	return fmt.Sprintf("%s/.gitignore", s.GetConfigDir())
+}
+
 func (s WorkspaceManager) resolveFunctionFile(name string) string {
 	return fmt.Sprintf("%s/functions.%s", s.getWorkspaceFunctionsDir(name), s.getExtension())
 }
@@ -349,7 +353,7 @@ func (s WorkspaceManager) getExtension() string {
 }
 
 func (s WorkspaceManager) createConfigFolder() error {
-	return os.MkdirAll(s.configDir, 0o777)
+	return errors.Join(os.MkdirAll(s.configDir, 0o777), os.WriteFile(s.resolveGitignoreFile(), []byte("*/envs/*\n"), 0o666))
 }
 
 func (s WorkspaceManager) createWorkspaceFolder(name string) error {


### PR DESCRIPTION
When the wo config folder is setup, create a .gitignore file to ignore all environments files to be able to push securely the workspaces on a git repository