### PR TITLE
Add several missing checks

### DIFF
--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -141,6 +141,9 @@ func (s WorkspaceManager) Get(name string) (Workspace, error) {
 }
 
 func (s WorkspaceManager) Create(name string, path string) error {
+	if s.hasWorkspace(name) {
+		return fmt.Errorf(`workspace "%s" already exists`, name)
+	}
 	err := s.createConfigFolder()
 	if err != nil {
 		return err
@@ -391,6 +394,11 @@ func (s WorkspaceManager) CreateEnvVariableStatement(name string, value string) 
 		return fmt.Sprintf("set -x -g %s %s", name, value)
 	}
 	return ""
+}
+
+func (s WorkspaceManager) hasWorkspace(name string) bool {
+	_, err := os.Stat(s.getWorkspaceDir(name))
+	return !os.IsNotExist(err)
 }
 
 func (s WorkspaceManager) getWorkspace(name string) (Workspace, error) {

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -265,6 +265,16 @@ func TestCreate(t *testing.T) {
 				assert.Equal(t, fmt.Sprintf("app = 'bash'\npath = '%s'\n", project.getPath(t)), string(b))
 			},
 		},
+		{
+			"Creating workspace twice fails",
+			func(t *testing.T, w WorkspaceManager) string {
+				assert.NoError(t, w.Create("test", project.getPath(t)))
+				return project.getPath(t)
+			},
+			func(t *testing.T, err error) {
+				assert.Error(t, err)
+			},
+		},
 	}
 	for _, s := range scenarios {
 		t.Run(s.name, func(t *testing.T) {

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -251,6 +251,16 @@ func TestCreate(t *testing.T) {
 			func(t *testing.T, err error) {
 				assert.NoError(t, err)
 				path := config.getPath(t)
+				_, err = os.Stat(path + "/config.toml")
+				assert.NoError(t, err)
+				b, err := os.ReadFile(path + "/config.toml")
+				assert.NoError(t, err)
+				assert.Equal(t, "shell = 'bash'\n", string(b))
+				_, err = os.Stat(path + "/.gitignore")
+				assert.NoError(t, err)
+				b, err = os.ReadFile(path + "/.gitignore")
+				assert.NoError(t, err)
+				assert.Equal(t, "*/envs/*\n", string(b))
 				envFile, err := os.Stat(path + "/test/envs/default.bash")
 				assert.NoError(t, err)
 				assert.Equal(t, "default.bash", envFile.Name())
@@ -260,7 +270,7 @@ func TestCreate(t *testing.T) {
 				configFile, err := os.Stat(path + "/test/config.toml")
 				assert.NoError(t, err)
 				assert.Equal(t, "config.toml", configFile.Name())
-				b, err := os.ReadFile(path + "/test/config.toml")
+				b, err = os.ReadFile(path + "/test/config.toml")
 				assert.NoError(t, err)
 				assert.Equal(t, fmt.Sprintf("app = 'bash'\npath = '%s'\n", project.getPath(t)), string(b))
 			},
@@ -273,6 +283,19 @@ func TestCreate(t *testing.T) {
 			},
 			func(t *testing.T, err error) {
 				assert.Error(t, err)
+			},
+		},
+		{
+			"Creating workspace with 2 different shells",
+			func(t *testing.T, w WorkspaceManager) string {
+				w1, err := NewWorkspaceManager(WithEditor("emacs", "emacs"), WithShellPath("/bin/zsh"), WithConfigPath(config.getPath(t)))
+				assert.NoError(t, err)
+				assert.NoError(t, w1.Create("test2", project.getPath(t)))
+				return project.getPath(t)
+			},
+			func(t *testing.T, err error) {
+				assert.Error(t, err)
+				t.Log(err)
 			},
 		},
 	}


### PR DESCRIPTION
* Returns an error when a workspace is created twice
* Force the use of a single shell for all workspaces